### PR TITLE
feat: Report available system memory under `dcc_free_mem`

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -34,12 +34,20 @@ jobs:
           mv -v   ./shellcheck-v*/shellcheck "./shellcheck"
           rm -rv  ./shellcheck-v*
           ./shellcheck --version
+      - name: "Install PyCodeStyle"
+        run: |
+          sudo apt-get install -y --no-install-recommends \
+            python3-pycodestyle
       - name: "ShellCheck"
         run: |
           ./shellcheck \
             --color=always \
             etc/cron.*/* \
             usr/local/*bin/*
+      - name: "PyCodeStyle"
+        run: |
+          python3 -m pycodestyle \
+            .
 
   build:
     name: "Build ${{ github.event_name == 'workflow_dispatch' && inputs.release && 'and Deploy' || '' }} Docker Image"
@@ -54,16 +62,87 @@ jobs:
         with:
           load: true
           tags: "distcc-docker:${{ env.RUNS_ON }}"
-      - name: "Simple test"
+      - name: "Test starting the container"
         run: |
           docker run \
             --init \
             --rm \
             "distcc-docker:${{ env.RUNS_ON }}" \
-            --jobs $(nproc) \
-            -- \
-            bash -c \
-              "set -x; ps fauxw; /usr/bin/ls -alh .; /usr/bin/ls -alh /var/log; cat /var/log/*; exit;"
+              --jobs $(nproc) \
+              -- \
+              bash -c \
+                "set -x; ps fauxw; /usr/bin/ls -alh .; /usr/bin/ls -alh /var/log; cat /var/log/*; exit;"
+      - name: "Test that \"dcc_free_mem\" is reported"
+        run: |
+          set -ex
+
+          docker run \
+            --detach \
+            --init \
+            --name "distcc-1" \
+            --publish "3632:3632/tcp" \
+            --publish "3633:3633/tcp" \
+            --rm \
+            "distcc-docker:${{ env.RUNS_ON }}" \
+              --jobs $(nproc) \
+              -- \
+                bash -c "set -x; sleep 120; exit;"
+
+          sleep 10
+          STAT_RESULT="$(curl "http://localhost:3633" | grep "dcc_free_mem")"
+          if [ -z "$STAT_RESULT" ]; then
+            echo "Server did not report 'dcc_free_mem'!" >&2
+            exit 1
+          fi
+
+          docker kill "distcc-1"
+      - name: "Test compilation in the container"
+        run: |
+          set -ex
+
+          sudo apt-get update -y
+          sudo apt-get install distcc g++ --no-install-recommends
+          sudo update-distcc-symlinks
+
+          docker run \
+            --detach \
+            --init \
+            --name "distcc-1" \
+            --publish "3632:3632/tcp" \
+            --publish "3633:3633/tcp" \
+            --rm \
+            "distcc-docker:${{ env.RUNS_ON }}" \
+              --jobs $(nproc) \
+              -- \
+                bash -c "set -x; sleep 120; exit;"
+
+          sleep 10
+          curl "http://localhost:3633"
+
+          echo "int main() { return MY_EXIT_CODE; }" >> main.cpp
+
+          DISTCC_HOSTS="127.0.0.1:3632/$(nproc),lzo" \
+            distcc /usr/bin/g++ \
+            -D MY_EXIT_CODE=42 \
+            -c \
+            ./main.cpp \
+            -o main.o
+
+          rm -v main.cpp
+
+          curl "http://localhost:3633" | grep "dcc_compile_ok 1"
+
+          docker kill "distcc-1"
+
+          /usr/bin/g++ main.o -o main
+
+          set +e
+
+          ./main
+          if [ "$?" -ne 42 ]; then
+            echo "Unexpected error code obtained!" >&2
+            exit 1
+          fi
       - name: "Log in to GitHub Container Registry (GHCR)"
         if: "github.ref == 'refs/heads/master' && github.event_name == 'workflow_dispatch' && inputs.release"
         uses: "docker/login-action@v3"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM ubuntu:20.04
 MAINTAINER Whisperity <whisperity-packages@protonmail.com>
 
 
-RUN export DEBIAN_FRONTEND=noninteractive && \
+RUN \
+  export DEBIAN_FRONTEND=noninteractive && \
   set -x && \
   apt-get update -y && \
   apt-get install -y --no-install-recommends \
@@ -15,6 +16,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     lsb-release \
     locales \
     logrotate \
+    python3 \
     wget \
   && \
   apt-get purge -y --auto-remove && \
@@ -24,7 +26,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
   mkdir -pv "/var/log/"
 
 
-RUN export DEBIAN_FRONTEND=noninteractive; \
+RUN \
+  export DEBIAN_FRONTEND=noninteractive; \
   sed -i -e "s/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/" "/etc/locale.gen" && \
   dpkg-reconfigure --frontend=noninteractive locales && \
   update-locale LANG="en_US.UTF-8"
@@ -34,11 +37,11 @@ ENV \
   LC_ALL="en_US.UTF-8"
 
 
+COPY usr/local/sbin/install-compilers.sh /usr/local/sbin/install-compilers.sh
+
 # Set to non-zero if the compilers should only be installed into the container,
 # and not immediately baked into the image itself.
 ARG LAZY_COMPILERS=0
-
-COPY usr/local/sbin/install-compilers.sh /usr/local/sbin/install-compilers.sh
 RUN \
   if [ "x$LAZY_COMPILERS" = "x0" ]; \
   then \
@@ -52,23 +55,24 @@ RUN \
   fi
 
 
+COPY etc/ /etc/
+COPY usr/ /usr/
+
+
 ARG USERNAME="distcc"
-RUN echo "Creating service user: $USERNAME ..." >&2 && \
-  mkdir -pv "/var/lib/distcc/" && \
-  chmod -Rv 755 "/var/lib/distcc" && \
+RUN \
+  cp -av "/etc/skel/." "/root/" && \
+  echo "Creating service user: $USERNAME ..." >&2 && \
   useradd "$USERNAME" \
-    --system \
+    --create-home \
     --comment "DistCC service" \
+    --home-dir "/var/lib/distcc/" \
     --shell "/bin/bash" \
-    --home-dir "/var/lib/distcc/" && \
-  cp -v "/root/.bashrc" "/root/.profile" "/var/lib/distcc/" && \
+    --system \
+    && \
   chown -Rv "$USERNAME":"$USERNAME" "/var/lib/distcc" && \
   echo "$USERNAME" > "/var/lib/distcc/distcc.user" && \
   chmod -v 444 "/var/lib/distcc/distcc.user"
-
-
-COPY etc/ /etc/
-COPY usr/ /usr/
 
 
 # Expose the DistCC server's normal job and statistics subservice port.

--- a/etc/logrotate.d/cron
+++ b/etc/logrotate.d/cron
@@ -1,6 +1,6 @@
 /var/log/cron.log {
   daily
-  rotate 30
+  rotate 7
 
   compress
   copytruncate

--- a/etc/logrotate.d/http
+++ b/etc/logrotate.d/http
@@ -1,4 +1,5 @@
-/var/log/distccd.log {
+/var/log/access.log
+/var/log/error.log {
   daily
   rotate 7
 

--- a/etc/logrotate.d/syslog
+++ b/etc/logrotate.d/syslog
@@ -1,4 +1,4 @@
-/var/log/distccd.log {
+/var/log/syslog {
   daily
   rotate 7
 

--- a/etc/skel/.config/htop/htoprc
+++ b/etc/skel/.config/htop/htoprc
@@ -1,0 +1,7 @@
+hide_kernel_threads=1
+hide_userland_threads=1
+highlight_base_name=1
+highlight_megabytes=1
+shadow_other_users=0
+show_program_path=0
+tree_view=1

--- a/usr/local/sbin/install-compilers.sh
+++ b/usr/local/sbin/install-compilers.sh
@@ -3,10 +3,11 @@
 #
 # Install LTS compiler versions into the image (or the container).
 
-COMPILERS_INSTALLED_STAMP="/var/lib/.distcc-compilers-done"
+COMPILERS_INSTALLED_STAMP="/var/lib/distcc-compilers-done"
 
 if [ -f "$COMPILERS_INSTALLED_STAMP" ]; then
-  echo "[^:)] The compilers are already installed appropriately, skipping..." >&2
+  echo "[^:)] The compilers are already installed appropriately," \
+    "skipping..." >&2
   exit 0
 else
   echo "[...] Installing C, C++ compilers..." >&2
@@ -62,7 +63,7 @@ if [[ "$OS_RELEASE" == "focal" ]]; then
     | cut -d ':' -f 6 \
     | cut -d ' ' -f 3)"
   apt-key adv --keyserver "hkp://keyserver.ubuntu.com:80" --recv-keys "$KEY"
-  mv "/etc/apt/trusted.gpg" "/etc/apt/keyrings/ubuntu-toolchain-r.gpg"
+  mv -v "/etc/apt/trusted.gpg" "/etc/apt/keyrings/ubuntu-toolchain-r.gpg"
 
   apt-get update -y
 
@@ -88,5 +89,5 @@ fi
 
 update-distcc-symlinks
 touch "$COMPILERS_INSTALLED_STAMP"
-chmod 444 "$COMPILERS_INSTALLED_STAMP"
+chmod -v 444 "$COMPILERS_INSTALLED_STAMP"
 exit 0

--- a/usr/local/share/dcc_free_mem/stat_server.py
+++ b/usr/local/share/dcc_free_mem/stat_server.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""
+Implements a transformating wrapper over the requests otherwise served by
+``distccd(1)``'s ``--stats`` server, otherwise known as a "man-in-the-middle"
+(MITM) access.
+This Python script injects the ``dcc_free_mem`` statistical variable into the
+output, with which clients can obtain the currently available system memory
+that could be consumeable by spawned compiler jobs, as returned by ``free(1)``.
+"""
+
+
+# Visually, the script can be summarised with the following communication
+# diagram:
+#
+#                                    DistCC Docker Container
+#                   ┌───────────────────────────────────────────────────────┐
+#                   │   ┌───────────────────┐                               │
+# ┌────┐ :3633 GET  │   │   Python server   │  :3634 GET  ┌───────────────┐ │
+# │HTTP├────────────┼───►    port :3633     ├─────────────► distccd stats │ │
+# └────┘            │   └───────▲─┬─────▲───┘             │   port :3634  │ │
+#                   │           │ │     │                 └───────┬───────┘ │
+# ┌────┐ :3634 GET  │           │ │     │   HTTP socket response  │         │
+# │HTTP├────────────┼──►X       │ │     └─────────────────────────┘         │
+# └────┘            │           │ │                                         │
+#                   │           │ │ subprocess I/O                          │
+#                   │           │ │                                         │
+#                   │   ┌───────┴─▼────────┐                                │
+#                   │   │ coreutils 'free' │                                │
+#                   │   └──────────────────┘                                │
+#                   └───────────────────────────────────────────────────────┘
+#
+
+
+import argparse
+import datetime
+import http
+import http.server
+import os
+import socket
+import subprocess
+import sys
+import urllib.request
+from typing import List, Optional, Union, cast
+
+
+def argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="""
+Serve `dcc_free_mem` alongside the reported statistics of a 'distccd' server.
+""",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument("listen_port",
+                        metavar="listen_port",
+                        type=int,
+                        help="""
+The TCP port to listen on where the extended statistics will be reported.
+"""
+                        )
+
+    parser.add_argument("stats_port",
+                        metavar="PORT",
+                        type=int,
+                        default=3633,
+                        help="""
+The statistics server's port number, as was passed to "distccd
+--stats-port=PORT".
+"""
+                        )
+
+    parser.add_argument("--access-log",
+                        type=str,
+                        default="/var/log/access.log",
+                        help="""
+Path to the webserver's output "access log" file.
+""")
+
+    parser.add_argument("--error-log",
+                        type=str,
+                        default="/var/log/error.log",
+                        help="""
+Path to the webserver's output "error log" file.
+""")
+
+    parser.add_argument("--system-log",
+                        type=str,
+                        default="/var/log/syslog",
+                        help="""
+Path to the standard "syslog" file.
+""")
+
+    return parser
+
+
+def _syslog(file: str, message: str, facility: str, pid: Optional[int] = None):
+    """
+    Logs one line to the "emulated" system log.
+    """
+    date = datetime.datetime.now().strftime("%b %_d %H:%M:%S")
+    hostname = socket.gethostname()
+    if not pid:
+        pid = os.getpid()
+    pid_str = f"[{pid}]".format(pid)
+    log_line = f"{date} {hostname} {facility}{pid_str}: {message}"
+
+    try:
+        with open(file, 'a') as io:
+            io.writelines([log_line])
+    except Exception:
+        print(log_line, file=sys.stderr)
+
+
+class DistCCStatsMITMRequestHandler(http.server.BaseHTTPRequestHandler):
+    def log_request(self,
+                    code: Union[int, str] = '-',
+                    size: Union[int, str] = '-'):
+        if isinstance(code, http.HTTPStatus):
+            code = code.value
+        self.log_access('"%s" %s %s', self.requestline, str(code), str(size))
+
+    def log_access(self, format: str, *args, **kwargs):
+        log = cast(DistCCStatsMITMHTTPServer, self.server).access_log
+        return self.log(format, log, *args, **kwargs)
+
+    def log_message(self, format: str, *args):
+        log = cast(DistCCStatsMITMHTTPServer, self.server).error_log
+        return self.log(format, log, *args)
+
+    def log(self, format: str, file: str, *args):
+        log_line = "%s - - [%s] %s\n" % \
+            (self.address_string(), self.log_date_time_string(), format % args)
+
+        try:
+            with open(file, 'a') as io:
+                io.writelines([log_line])
+        except Exception:
+            log = cast(DistCCStatsMITMHTTPServer, self.server).system_log
+            _syslog(log,
+                    f"{self.__class__.__name__} failed to log a message "
+                    f"to file \"{file}\":",
+                    "stat_server.py")
+            _syslog(log,
+                    log_line.rstrip(),
+                    "stat_server.py")
+            print(log_line, file=sys.stderr)
+
+    def do_GET(self):
+        stats_port = cast(DistCCStatsMITMHTTPServer, self.server).stats_port
+
+        try:
+            with urllib.request.urlopen(f"http://0.0.0.0:{stats_port}") \
+                    as distccd_response_obj:
+                distccd_response = distccd_response_obj.read().decode()
+                code = distccd_response_obj.code
+                headers = distccd_response_obj.headers
+        except Exception:
+            import traceback
+            return self.send_error(http.HTTPStatus.INTERNAL_SERVER_ERROR,
+                                   "An exception occurred when querying the "
+                                   f"--stats server at :{stats_port}",
+                                   traceback.format_exc())
+
+        def _mimic_response_headers(size: Union[str, int] = '-',
+                                    override_code: Optional[int] = None):
+            code_ = code
+            if override_code:
+                if isinstance(override_code, http.HTTPStatus):
+                    override_code = override_code.value
+                code_ = override_code
+
+            self.log_request(code_, size)
+            self.send_response_only(code_)
+            for header, value in headers.items():
+                self.send_header(header, value)
+            self.end_headers()
+
+        def _send_response(response: bytes,
+                           override_code: Optional[int] = None):
+            _mimic_response_headers(len(response), override_code)
+            self.wfile.write(response)
+
+        if not distccd_response \
+                or "<distccstats>" not in distccd_response \
+                or "</distccstats>" not in distccd_response:
+            self.log_error(
+                "%s",
+                f"--stats at :{stats_port} returned empty or invalid response")
+
+            return _send_response(b'', http.HTTPStatus.NO_CONTENT)
+
+        if "dcc_free_mem" in distccd_response:
+            _server = cast(DistCCStatsMITMHTTPServer, self.server)
+            if not _server.has_warned_about_being_unnecessary:
+                _server.has_warned_about_being_unnecessary = True
+                _syslog(_server.system_log,
+                        "'dcc_free_mem' found in the output of native "
+                        "'distccd', the wrapper is now unnecessary!",
+                        "stat_server.py")
+                self.log_error("%s", "'stat_server.py' is unnecessary!")
+
+            return _send_response(distccd_response.encode())
+
+        dcc_free_mem: Optional[int] = None
+        try:
+            free_result = subprocess. \
+                check_output(["free", "--mebi", "--wide"]). \
+                decode().splitlines()
+            for line in free_result:
+                if line.startswith("Mem:"):
+                    values = list(filter(bool, line.split(' ')))
+                    dcc_free_mem = int(values[-1])
+
+            if dcc_free_mem is None:
+                raise ValueError(
+                    "No 'Mem:' line found in the output of `free`")
+        except Exception:
+            import traceback
+            traceback.print_exc()
+            self.log_error("%s", "Failed to get valid response from `free`!")
+
+            return _send_response(
+                distccd_response.encode(),
+                http.HTTPStatus.NON_AUTHORITATIVE_INFORMATION)
+
+        response_lines: List[str] = distccd_response.splitlines()
+        response_lines.insert(-1, "dcc_free_mem %d MB" % dcc_free_mem)
+        response_lines.append('')
+
+        return _send_response('\n'.join(response_lines).encode())
+
+
+class DistCCStatsMITMHTTPServer(http.server.HTTPServer):
+    def __init__(self, server_address, bind_and_activate, stats_port: int,
+                 access_log: str, error_log: str, system_log: str):
+        super().__init__(server_address,
+                         DistCCStatsMITMRequestHandler,
+                         bind_and_activate)
+        self.stats_port = stats_port
+        self.access_log = access_log
+        self.error_log = error_log
+        self.system_log = system_log
+        self.has_warned_about_being_unnecessary = False
+
+
+def main(args: argparse.Namespace) -> int:
+    server = DistCCStatsMITMHTTPServer(
+        server_address=("0.0.0.0", args.listen_port),
+        bind_and_activate=True,
+        stats_port=args.stats_port,
+        access_log=args.access_log,
+        error_log=args.error_log,
+        system_log=args.system_log
+    )
+
+    server.serve_forever()
+
+    return 0
+
+
+if __name__ == "__main__":
+    opts = argument_parser()
+    args = opts.parse_args()
+    sys.exit(main(args) or 0)


### PR DESCRIPTION
Closes #1.

This patch adds a trivial wrapper HTTP server, written in Python, that intercepts the requests going towards the `--stats-port` of the running `distccd` server.
It relays the request verbatim at first, and if the response is a valid statistics message, extends it at the bottom with a line

    dcc_free_mem 16384 MB

where the numeric value is obtained from `free`'s output under **Available** system memory.